### PR TITLE
feat(mcp): expose registerMiddleware / registerMiddlewares on strapi.ai.mcp

### DIFF
--- a/docs/docs/docs/01-core/strapi/mcp-server.md
+++ b/docs/docs/docs/01-core/strapi/mcp-server.md
@@ -25,7 +25,7 @@ Source: `packages/core/core/src/services/mcp/`, `packages/core/core/src/provider
 | Extensibility    | Any plugin or app can register tools/prompts/resources via `strapi.ai.mcp.register*` during the register phase |
 | Route middleware | `strapi.ai.mcp.registerMiddleware(...)` during the register phase — attaches to `POST /mcp` only               |
 | Built-in         | One dev-only `log` tool (core) + one CRUD tool set per displayed content type (content-manager)                |
-| SDK              | `@modelcontextprotocol/sdk@1.29.0`                                                                             |
+| SDK              | `@modelcontextprotocol/sdk@1.30.0`                                                                             |
 
 ## Architecture
 
@@ -116,7 +116,10 @@ Strapi's normal route pipeline, so all three forms behave exactly as they do on 
 It runs **before** the MCP request handler, in registration order.
 
 The `GET`/`PUT`/`PATCH`/`DELETE` method-not-allowed routes are deliberately left bare — they
-exist only to return a parseable JSON-RPC error.
+exist only to return a parseable JSON-RPC error, and are not covered by registered middleware —
+rate limits and IP filters apply to `POST` only.
+
+Route-level `policies` support is deliberately deferred for the MCP route — see `services/mcp/routes.ts`.
 
 :::caution
 Like `registerTool`, these throw once `strapi.ai.mcp` has left the `idle` status. Register from a

--- a/docs/docs/docs/01-core/strapi/mcp-server.md
+++ b/docs/docs/docs/01-core/strapi/mcp-server.md
@@ -15,16 +15,17 @@ Source: `packages/core/core/src/services/mcp/`, `packages/core/core/src/provider
 
 ## Summary
 
-| Concern       | Answer                                                                                                         |
-| ------------- | -------------------------------------------------------------------------------------------------------------- |
-| Enable        | `server.mcp.enabled` (default `false`)                                                                         |
-| Endpoint      | `POST /mcp` (fixed path, not configurable)                                                                     |
-| Transport     | MCP SDK `StreamableHTTPServerTransport`, stateless (one server instance per request)                           |
-| Auth          | Admin API token (`Authorization: Bearer <token>`) — same store as Settings → API Tokens (admin)                |
-| Authorization | Two layers: coarse session capability gate (CASL ability vs `auth.policies`) + fine-grained handler checks     |
-| Extensibility | Any plugin or app can register tools/prompts/resources via `strapi.ai.mcp.register*` during the register phase |
-| Built-in      | One dev-only `log` tool (core) + one CRUD tool set per displayed content type (content-manager)                |
-| SDK           | `@modelcontextprotocol/sdk@1.29.0`                                                                             |
+| Concern          | Answer                                                                                                         |
+| ---------------- | -------------------------------------------------------------------------------------------------------------- |
+| Enable           | `server.mcp.enabled` (default `false`)                                                                         |
+| Endpoint         | `POST /mcp` (fixed path, not configurable)                                                                     |
+| Transport        | MCP SDK `StreamableHTTPServerTransport`, stateless (one server instance per request)                           |
+| Auth             | Admin API token (`Authorization: Bearer <token>`) — same store as Settings → API Tokens (admin)                |
+| Authorization    | Two layers: coarse session capability gate (CASL ability vs `auth.policies`) + fine-grained handler checks     |
+| Extensibility    | Any plugin or app can register tools/prompts/resources via `strapi.ai.mcp.register*` during the register phase |
+| Route middleware | `strapi.ai.mcp.registerMiddleware(...)` during the register phase — attaches to `POST /mcp` only               |
+| Built-in         | One dev-only `log` tool (core) + one CRUD tool set per displayed content type (content-manager)                |
+| SDK              | `@modelcontextprotocol/sdk@1.29.0`                                                                             |
 
 ## Architecture
 
@@ -83,6 +84,52 @@ All five routes set `config: { auth: false }` — Strapi's own admin/content-API
 The transport is the MCP SDK's `StreamableHTTPServerTransport` with `sessionIdGenerator: undefined`, i.e. **stateless**: a fresh `McpServer` instance is created and connected for every POST request, then closed in a `finally` block (`packages/core/core/src/services/mcp/handlers/handlePost.ts`).
 
 An OAuth discovery fallback middleware (`middleware/oauthDiscoveryFallback.ts`) intercepts `/.well-known/oauth-*` and `/register` with a plain JSON 404, since some MCP clients probe these paths and would otherwise hit Strapi's default HTML 404 page.
+
+## Route middleware
+
+`/mcp` is a public HTTP surface with `auth: false` at the router level, so it is a natural place
+for the protections you already apply elsewhere — rate limiting, IP filtering, request logging.
+Attach them with `registerMiddleware`, from the same register phase used for capabilities:
+
+```ts
+// src/index.ts, or a plugin's register()
+register({ strapi }) {
+  // inline handler
+  strapi.ai.mcp.registerMiddleware(async (ctx, next) => {
+    strapi.log.info(`[mcp] ${ctx.method} from ${ctx.ip}`);
+    await next();
+  });
+
+  // by UID
+  strapi.ai.mcp.registerMiddleware('global::rate-limit');
+
+  // by UID, with config
+  strapi.ai.mcp.registerMiddleware({ name: 'global::rate-limit', config: { max: 100 } });
+
+  // batch — runs in array order
+  strapi.ai.mcp.registerMiddlewares(['global::rate-limit', async (ctx, next) => next()]);
+}
+```
+
+Registered middleware is attached to the POST route's `config.middlewares` and resolved by
+Strapi's normal route pipeline, so all three forms behave exactly as they do on any other route.
+It runs **before** the MCP request handler, in registration order.
+
+The `GET`/`PUT`/`PATCH`/`DELETE` method-not-allowed routes are deliberately left bare — they
+exist only to return a parseable JSON-RPC error.
+
+:::caution
+Like `registerTool`, these throw once `strapi.ai.mcp` has left the `idle` status. Register from a
+plugin's `register()` (preferred) or `bootstrap()`; app-level `bootstrap()` is too late.
+:::
+
+:::caution
+`handlePost` sets `ctx.respond = false` and the MCP SDK writes directly to the raw
+`ServerResponse`. A middleware that inspects the response _after_ `await next()` will therefore
+find `ctx.body` empty and `ctx.status` unset — the response has already gone to the socket.
+Middleware that only gates or observes the **request** works normally; middleware that needs to
+read or rewrite the response must wrap `ctx.res.write` / `ctx.res.end` itself.
+:::
 
 ## Authentication
 

--- a/packages/core/core/src/services/mcp/__tests__/routes.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/routes.test.ts
@@ -33,6 +33,7 @@ describe('MCP Routes', () => {
           handler: expect.any(Function),
           config: {
             auth: false,
+            middlewares: [],
           },
         },
         {
@@ -143,6 +144,43 @@ describe('MCP Routes', () => {
           r.path === '/register'
       );
       expect(oauthPaths).toHaveLength(0);
+    });
+
+    describe('middlewares', () => {
+      test('POST route carries an empty middlewares array by default', () => {
+        const routes = createMcpRoutes(mockConfig, mockHandlers);
+        const post = routes.find((route) => route.method === 'POST');
+
+        expect(post?.config).toStrictEqual({ auth: false, middlewares: [] });
+      });
+
+      test('attaches middlewares to the POST route in registration order', () => {
+        const first = jest.fn(async (_ctx: any, next: any) => next());
+        const second = jest.fn(async (_ctx: any, next: any) => next());
+
+        const routes = createMcpRoutes(mockConfig, mockHandlers, [
+          'global::rate-limit',
+          first,
+          { name: 'global::ip-filter', config: { allow: ['127.0.0.1'] } },
+          second,
+        ]);
+        const post = routes.find((route) => route.method === 'POST');
+
+        expect(post?.config?.middlewares).toStrictEqual([
+          'global::rate-limit',
+          first,
+          { name: 'global::ip-filter', config: { allow: ['127.0.0.1'] } },
+          second,
+        ]);
+      });
+
+      test('does not attach middlewares to the method-not-allowed routes', () => {
+        const routes = createMcpRoutes(mockConfig, mockHandlers, ['global::rate-limit']);
+
+        for (const route of routes.filter((r) => r.method !== 'POST')) {
+          expect(route.config).toStrictEqual({ auth: false });
+        }
+      });
     });
   });
 

--- a/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
@@ -254,6 +254,26 @@ describe('MCP Service Integration', () => {
       // Try to start again without stopping
       await expect(service.start()).rejects.toThrow('[MCP] Server already started or starting');
     });
+
+    test('should leave the service not-running and surface a clear error when route registration fails', async () => {
+      mockServerRoutes.mockImplementation(() => {
+        throw new Error('Middleware global::rate-limt not found.');
+      });
+
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await expect(service.start()).rejects.toThrow(
+        '[MCP] Failed to register MCP routes — check middlewares passed to registerMiddleware(): Middleware global::rate-limt not found.'
+      );
+
+      expect(service.isRunning()).toBe(false);
+
+      // The error status is sticky: a second start() attempt is rejected too,
+      // not silently retried, since serverStatus is now 'error' not 'starting'.
+      await expect(service.start()).rejects.toThrow(
+        '[MCP] Cannot start server: previous error state'
+      );
+    });
   });
 
   describe('middleware registration', () => {

--- a/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
+++ b/packages/core/core/src/services/mcp/__tests__/service-integration.test.ts
@@ -255,4 +255,94 @@ describe('MCP Service Integration', () => {
       await expect(service.start()).rejects.toThrow('[MCP] Server already started or starting');
     });
   });
+
+  describe('middleware registration', () => {
+    const getPostRoute = () => {
+      const routes = mockServerRoutes.mock.calls[0][0];
+      return routes.find((route: any) => route.method === 'POST');
+    };
+
+    test('registers an inline handler onto the POST route', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+      const handler = jest.fn(async (_ctx: any, next: any) => next());
+
+      service.registerMiddleware(handler);
+      await service.start();
+
+      expect(getPostRoute().config.middlewares).toStrictEqual([handler]);
+    });
+
+    test('registers a middleware UID string', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      service.registerMiddleware('global::rate-limit');
+      await service.start();
+
+      expect(getPostRoute().config.middlewares).toStrictEqual(['global::rate-limit']);
+    });
+
+    test('registers the { name, config } object form', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      service.registerMiddleware({ name: 'global::rate-limit', config: { max: 100 } });
+      await service.start();
+
+      expect(getPostRoute().config.middlewares).toStrictEqual([
+        { name: 'global::rate-limit', config: { max: 100 } },
+      ]);
+    });
+
+    test('registerMiddlewares appends a batch, preserving order', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+      const inline = jest.fn(async (_ctx: any, next: any) => next());
+
+      service.registerMiddleware('global::first');
+      service.registerMiddlewares(['global::second', inline]);
+      await service.start();
+
+      expect(getPostRoute().config.middlewares).toStrictEqual([
+        'global::first',
+        'global::second',
+        inline,
+      ]);
+    });
+
+    test('leaves the POST middlewares empty when none are registered', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      await service.start();
+
+      expect(getPostRoute().config.middlewares).toStrictEqual([]);
+    });
+
+    test('throws when registerMiddleware is called after start', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+      await service.start();
+
+      expect(() => service.registerMiddleware('global::rate-limit')).toThrow(
+        '[MCP] Cannot register middlewares after the MCP server has started.'
+      );
+    });
+
+    test('throws when registerMiddlewares is called after start', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+      await service.start();
+
+      expect(() => service.registerMiddlewares(['global::rate-limit'])).toThrow(
+        '[MCP] Cannot register middlewares after the MCP server has started.'
+      );
+    });
+
+    test('does not attach middlewares to the method-not-allowed routes', async () => {
+      const service = createMcpService(mockStrapi as Core.Strapi);
+
+      service.registerMiddleware('global::rate-limit');
+      await service.start();
+
+      const routes = mockServerRoutes.mock.calls[0][0];
+      for (const route of routes.filter((r: any) => r.method !== 'POST')) {
+        expect(route.config).toStrictEqual({ auth: false });
+      }
+    });
+  });
 });

--- a/packages/core/core/src/services/mcp/index.ts
+++ b/packages/core/core/src/services/mcp/index.ts
@@ -38,6 +38,10 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
     Modules.MCP.McpResourceDefinition
   >('resource');
 
+  // Middlewares attached to POST /mcp, in registration order. Resolution of
+  // each entry is left to Strapi's route pipeline at start().
+  const routeMiddlewares: Modules.MCP.McpMiddleware[] = [];
+
   // Prepare handler dependencies
   const handlerDependencies: McpHandlerDependencies = {
     strapi,
@@ -85,6 +89,22 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
       resourceDefinitions.define(resource);
     },
 
+    registerMiddleware(middleware) {
+      if (serverStatus !== 'idle') {
+        throw new Error('[MCP] Cannot register middlewares after the MCP server has started.');
+      }
+
+      routeMiddlewares.push(middleware);
+    },
+
+    registerMiddlewares(middlewares) {
+      if (serverStatus !== 'idle') {
+        throw new Error('[MCP] Cannot register middlewares after the MCP server has started.');
+      }
+
+      routeMiddlewares.push(...middlewares);
+    },
+
     async start() {
       if (service.isEnabled() === false) {
         strapi.log.debug('[MCP] Server is disabled');
@@ -100,7 +120,7 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
 
       strapi.server.use(createOAuthDiscoveryFallbackMiddleware());
 
-      const routes = createMcpRoutes(config, { handlePost });
+      const routes = createMcpRoutes(config, { handlePost }, routeMiddlewares);
       strapi.server.routes(routes);
 
       serverStatus = 'running';

--- a/packages/core/core/src/services/mcp/index.ts
+++ b/packages/core/core/src/services/mcp/index.ts
@@ -120,8 +120,17 @@ export const createMcpService = (strapi: Core.Strapi): Modules.MCP.McpService =>
 
       strapi.server.use(createOAuthDiscoveryFallbackMiddleware());
 
-      const routes = createMcpRoutes(config, { handlePost }, routeMiddlewares);
-      strapi.server.routes(routes);
+      try {
+        const routes = createMcpRoutes(config, { handlePost }, [...routeMiddlewares]);
+        strapi.server.routes(routes);
+      } catch (error) {
+        serverStatus = 'error';
+        throw new Error(
+          `[MCP] Failed to register MCP routes — check middlewares passed to registerMiddleware(): ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
 
       serverStatus = 'running';
 

--- a/packages/core/core/src/services/mcp/routes.ts
+++ b/packages/core/core/src/services/mcp/routes.ts
@@ -27,6 +27,8 @@ export type McpRouteHandlers = {
  * should not run user code. Resolution of each entry (UID string, inline
  * handler, or `{ name, config }`) is left to Strapi's route pipeline.
  *
+ * // TODO: policies support on the MCP route is deferred.
+ *
  * @internal
  */
 export const createMcpRoutes = (

--- a/packages/core/core/src/services/mcp/routes.ts
+++ b/packages/core/core/src/services/mcp/routes.ts
@@ -1,4 +1,4 @@
-import type { Core } from '@strapi/types';
+import type { Core, Modules } from '@strapi/types';
 import { McpConfiguration } from './internal/McpConfiguration';
 import { sendJsonRpcError } from './utils/sendJsonRpcError';
 
@@ -21,16 +21,28 @@ export type McpRouteHandlers = {
 
 /**
  * Creates MCP route definitions for registration with Strapi server.
+ *
+ * Caller-supplied middlewares are attached to the POST route only — the
+ * method-not-allowed routes exist to return a parseable JSON-RPC error and
+ * should not run user code. Resolution of each entry (UID string, inline
+ * handler, or `{ name, config }`) is left to Strapi's route pipeline.
+ *
  * @internal
  */
 export const createMcpRoutes = (
   config: McpConfiguration,
-  handlers: McpRouteHandlers
+  handlers: McpRouteHandlers,
+  middlewares: Modules.MCP.McpMiddleware[] = []
 ): Omit<Core.Route, 'info'>[] => {
   const noAuth = { auth: false } as const;
 
   return [
-    { method: 'POST', path: config.path, handler: handlers.handlePost, config: noAuth },
+    {
+      method: 'POST',
+      path: config.path,
+      handler: handlers.handlePost,
+      config: { ...noAuth, middlewares },
+    },
     { method: 'GET', path: config.path, handler: handleMethodNotAllowed, config: noAuth },
     { method: 'DELETE', path: config.path, handler: handleMethodNotAllowed, config: noAuth },
     { method: 'PUT', path: config.path, handler: handleMethodNotAllowed, config: noAuth },

--- a/packages/core/types/src/core/route.ts
+++ b/packages/core/types/src/core/route.ts
@@ -1,6 +1,6 @@
 import type { z } from 'zod/v4';
 import type { LiteralUnion } from '../utils/string';
-import type { MiddlewareHandler } from './middleware';
+import type { MiddlewareConfig, MiddlewareHandler, MiddlewareName } from './middleware';
 
 export type RouteInfo = {
   apiName?: string;
@@ -10,7 +10,9 @@ export type RouteInfo = {
 
 export type RouteConfig = {
   prefix?: string;
-  middlewares?: Array<string | MiddlewareHandler>;
+  // `resolveMiddlewares` has always accepted the object form at runtime; the
+  // type lagged behind it.
+  middlewares?: Array<MiddlewareName | MiddlewareConfig | MiddlewareHandler>;
   policies?: Array<string | { name: string; config: unknown }>;
   auth?: false | { scope?: string[]; strategies?: string[] };
 };

--- a/packages/core/types/src/core/route.ts
+++ b/packages/core/types/src/core/route.ts
@@ -12,7 +12,9 @@ export type RouteConfig = {
   prefix?: string;
   // `resolveMiddlewares` has always accepted the object form at runtime; the
   // type lagged behind it.
-  middlewares?: Array<MiddlewareName | MiddlewareConfig | MiddlewareHandler>;
+  middlewares?: Array<
+    MiddlewareName | (MiddlewareConfig & { name: MiddlewareName }) | MiddlewareHandler
+  >;
   policies?: Array<string | { name: string; config: unknown }>;
   auth?: false | { scope?: string[]; strategies?: string[] };
 };

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -283,6 +283,17 @@ export interface McpResourceBuilder {
   ): McpResourceDefinitionFields<Name> & McpAuthAccess;
 }
 
+/**
+ * A middleware attachable to the MCP HTTP route via
+ * {@link McpService.registerMiddleware}. Accepts the same forms as a Strapi
+ * route's `config.middlewares`: a UID string, an inline handler, or a
+ * `{ name, config }` object.
+ */
+export type McpMiddleware =
+  | Core.MiddlewareName
+  | Core.MiddlewareConfig
+  | Core.MiddlewareHandler;
+
 export type McpServiceStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'error';
 
 /**

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -289,7 +289,10 @@ export interface McpResourceBuilder {
  * route's `config.middlewares`: a UID string, an inline handler, or a
  * `{ name, config }` object.
  */
-export type McpMiddleware = Core.MiddlewareName | Core.MiddlewareConfig | Core.MiddlewareHandler;
+export type McpMiddleware =
+  | Core.MiddlewareName
+  | (Core.MiddlewareConfig & { name: Core.MiddlewareName })
+  | Core.MiddlewareHandler;
 
 export type McpServiceStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'error';
 
@@ -297,8 +300,9 @@ export type McpServiceStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'e
  * Service providing Model Context Protocol (MCP) capabilities.
  * Available on strapi.ai.mcp.
  *
- * Call `registerTool`, `registerPrompt`, and `registerResource` only during
- * Strapi's register phase. The MCP HTTP server starts during bootstrap.
+ * Call `registerTool`, `registerPrompt`, `registerResource`, and
+ * `registerMiddleware` only during Strapi's register phase. The MCP HTTP
+ * server starts during bootstrap.
  */
 export interface McpService {
   /**

--- a/packages/core/types/src/modules/mcp.ts
+++ b/packages/core/types/src/modules/mcp.ts
@@ -289,10 +289,7 @@ export interface McpResourceBuilder {
  * route's `config.middlewares`: a UID string, an inline handler, or a
  * `{ name, config }` object.
  */
-export type McpMiddleware =
-  | Core.MiddlewareName
-  | Core.MiddlewareConfig
-  | Core.MiddlewareHandler;
+export type McpMiddleware = Core.MiddlewareName | Core.MiddlewareConfig | Core.MiddlewareHandler;
 
 export type McpServiceStatus = 'idle' | 'starting' | 'running' | 'stopping' | 'error';
 
@@ -376,6 +373,25 @@ export interface McpService {
   registerResource<Name extends string>(
     resource: McpResourceDefinitionFields<Name> & McpAuthAccess
   ): void;
+
+  /**
+   * Attach a middleware to the MCP HTTP route (POST /mcp). It runs before the
+   * MCP request handler, in registration order.
+   *
+   * Must be called while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
+   * In Strapi's load lifecycle, call only from the register phase (plugin register() or app register()).
+   * @throws Error if called after the MCP server has started
+   */
+  registerMiddleware(middleware: McpMiddleware): void;
+
+  /**
+   * Attach several middlewares to the MCP HTTP route (POST /mcp), in array order.
+   * Equivalent to calling {@link McpService.registerMiddleware} for each entry.
+   *
+   * Must be called while strapi.ai.mcp is idle, before strapi.ai.mcp.start() runs.
+   * @throws Error if called after the MCP server has started
+   */
+  registerMiddlewares(middlewares: McpMiddleware[]): void;
 
   /**
    * Start the MCP server

--- a/tests/api/core/mcp/mcp-middleware.test.api.ts
+++ b/tests/api/core/mcp/mcp-middleware.test.api.ts
@@ -84,8 +84,66 @@ describe('MCP route middleware (api)', () => {
   });
 
   test('does not run registered middleware on unrelated routes', async () => {
-    await createAgent(strapi)({ url: '/_health', method: 'GET' });
+    // /_health is registered directly on the router and never passes through
+    // composeEndpoint, so it wouldn't prove anything about route middleware.
+    // /admin/init does go through the normal route pipeline.
+    await createAgent(strapi)({ url: '/admin/init', method: 'GET' });
 
     expect(calls).toStrictEqual([]);
+  });
+});
+
+describe('MCP route middleware (api) — blocking middleware', () => {
+  let strapi: Core.Strapi;
+
+  beforeAll(async () => {
+    strapi = await createStrapiInstance({
+      register({ strapi: instance }) {
+        instance.config.set('features.future.adminTokens', true);
+        instance.config.set('server.mcp.enabled', true);
+
+        // A gate middleware that declines the request outright: it sets its
+        // own status/body and never calls `next()`. This proves a middleware
+        // can actually block the request, not just observe it — the whole
+        // point of exposing registerMiddleware (rate limiting, IP filtering).
+        instance.ai.mcp.registerMiddleware(async (ctx: any) => {
+          ctx.status = 429;
+          ctx.body = { blocked: true, reason: 'rate-limited-by-test-gate' };
+          // Deliberately no call to next(): handlePost must never run.
+        });
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+  });
+
+  test('a middleware that does not call next() blocks the request before the handler runs', async () => {
+    const res = await createAgent(strapi)({
+      url: '/mcp',
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: MCP_PROTOCOL_VERSION,
+          capabilities: {},
+          clientInfo: { name: 'mcp-middleware-test', version: '1.0.0' },
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(429);
+    // The gate middleware's own body, not handlePost's JSON-RPC
+    // AUTHENTICATION_REQUIRED envelope — proof handlePost never ran.
+    expect(res.body).toStrictEqual({ blocked: true, reason: 'rate-limited-by-test-gate' });
+    expect(res.body).not.toHaveProperty('jsonrpc');
+    expect(res.body).not.toHaveProperty('error');
   });
 });

--- a/tests/api/core/mcp/mcp-middleware.test.api.ts
+++ b/tests/api/core/mcp/mcp-middleware.test.api.ts
@@ -1,0 +1,90 @@
+import { createStrapiInstance } from 'api-tests/strapi';
+import { createAgent } from 'api-tests/agent';
+import type { Core } from '@strapi/types';
+
+const MCP_PROTOCOL_VERSION = '2025-06-18';
+const UID_MIDDLEWARE = 'global::mcp-test-marker';
+
+/** Records the order in which guards ran, and what they saw. */
+const calls: string[] = [];
+
+describe('MCP route middleware (api)', () => {
+  let strapi: Core.Strapi;
+
+  beforeAll(async () => {
+    strapi = await createStrapiInstance({
+      register({ strapi: instance }) {
+        instance.config.set('features.future.adminTokens', true);
+        instance.config.set('server.mcp.enabled', true);
+
+        // A middleware registered by UID, exactly as an app would ship one.
+        instance
+          .get('middlewares')
+          .set(UID_MIDDLEWARE, (config: any) => async (ctx: any, next: any) => {
+            calls.push(`uid:${config?.marker ?? 'none'}`);
+            await next();
+          });
+
+        instance.ai.mcp.registerMiddlewares([
+          async (ctx: any, next: any) => {
+            // Runs before the MCP handler, so nothing has been written yet.
+            calls.push(`inline:${ctx.method} ${ctx.path} respond=${ctx.respond !== false}`);
+            await next();
+          },
+          { name: UID_MIDDLEWARE, config: { marker: 'configured' } },
+        ]);
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await strapi.destroy();
+  });
+
+  beforeEach(() => {
+    calls.length = 0;
+  });
+
+  const postMcp = (body: Record<string, unknown>) =>
+    createAgent(strapi)({
+      url: '/mcp',
+      method: 'POST',
+      headers: {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+      },
+      body,
+    });
+
+  test('runs registered middleware on POST /mcp, in order, before the handler', async () => {
+    // No Authorization header: the MCP handler answers 401. The middlewares
+    // still ran, which is precisely what we are asserting — they sit upstream
+    // of the handler.
+    const res = await postMcp({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'mcp-middleware-test', version: '1.0.0' },
+      },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(calls).toStrictEqual(['inline:POST /mcp respond=true', 'uid:configured']);
+  });
+
+  test('does not run registered middleware on the method-not-allowed routes', async () => {
+    const res = await createAgent(strapi)({ url: '/mcp', method: 'GET' });
+
+    expect(res.statusCode).toBe(405);
+    expect(calls).toStrictEqual([]);
+  });
+
+  test('does not run registered middleware on unrelated routes', async () => {
+    await createAgent(strapi)({ url: '/_health', method: 'GET' });
+
+    expect(calls).toStrictEqual([]);
+  });
+});

--- a/tests/api/core/mcp/mcp-middleware.test.api.ts
+++ b/tests/api/core/mcp/mcp-middleware.test.api.ts
@@ -31,6 +31,7 @@ describe('MCP route middleware (api)', () => {
             calls.push(`inline:${ctx.method} ${ctx.path} respond=${ctx.respond !== false}`);
             await next();
           },
+          UID_MIDDLEWARE,
           { name: UID_MIDDLEWARE, config: { marker: 'configured' } },
         ]);
       },
@@ -72,7 +73,7 @@ describe('MCP route middleware (api)', () => {
     });
 
     expect(res.statusCode).toBe(401);
-    expect(calls).toStrictEqual(['inline:POST /mcp respond=true', 'uid:configured']);
+    expect(calls).toStrictEqual(['inline:POST /mcp respond=true', 'uid:none', 'uid:configured']);
   });
 
   test('does not run registered middleware on the method-not-allowed routes', async () => {


### PR DESCRIPTION
Exposes a public API on `strapi.ai.mcp` so plugins and application code can attach middleware to the MCP HTTP route before the server starts. This lets existing Strapi middleware — rate limiting, IP filtering, custom auth — protect the public `POST /mcp` endpoint.

## API

```ts
register({ strapi }) {
  strapi.ai.mcp.registerMiddleware(async (ctx, next) => { await next(); });   // inline
  strapi.ai.mcp.registerMiddleware('global::rate-limit');                     // UID
  strapi.ai.mcp.registerMiddleware({ name: 'global::rate-limit', config: { max: 100 } });
  strapi.ai.mcp.registerMiddlewares(['global::ip-filter', async (ctx, next) => next()]);
}
```

## Design

The service does **not** resolve middleware itself. It collects an ordered array and hands it to `createMcpRoutes`, which attaches it to the **POST** route's `config.middlewares`. Strapi's existing pipeline (`composeEndpoint` → `resolveRouteMiddlewares` → `resolveMiddlewares`) does the resolution, so all three input forms work without any new resolution code — and the issue's "managed by strapi routes automatically" requirement is satisfied by construction. This mirrors existing core precedent (`admin/server/src/routes/authentication.ts` uses `middlewares: ['admin::rateLimit']`).

Middleware is attached to POST only. The GET/PUT/PATCH/DELETE routes exist solely to return a parseable JSON-RPC 405 and should not run user code.

Registration is guarded by the same `idle` lifecycle check as `registerTool`, and throws `[MCP] Cannot register middlewares after the MCP server has started.` once the server has started.

## Two things reviewers should know

**1. `createMcpRoutes` can now throw.** It previously could not. An unresolvable middleware UID makes `resolveMiddlewares` throw, and because the POST route is registered first, that fails *all five* `/mcp` routes. `start()` now catches this, sets `serverStatus = 'error'` (previously it was left at `'starting'`, which made the existing error guard dead code and caused `destroy()` to skip `stop()`), and rethrows naming `registerMiddleware()`. A typo now produces an actionable error instead of a silently missing endpoint.

**2. `RouteConfig['middlewares']` is widened — a type-level breaking change.** It now admits the `{ name, config }` object form that `resolveMiddlewares` has always accepted at runtime. `name` is required on that form, matching `validateRouteConfig`'s requirement (without the intersection, `{}` and `{ resolve: './mw' }` would typecheck and then throw at boot). This can break a third party that *reads* this type and narrows on `typeof m === 'string'`. In core, `resolveRouteMiddlewares` is the only reader and already declared the wider parameter type; every other site is a producer.

## Tests

| | |
|---|---|
| Unit | 181/181 across 17 files |
| API | `tests/api/core/mcp/` — 20 passed, 4 skipped (EE-only) |
| Typecheck | `@strapi/types` + `@strapi/core` — 0 errors |
| Lint | clean |

`tests/api/core/mcp/mcp-middleware.test.api.ts` proves over real HTTP that all three forms resolve and execute in registration order, that a middleware declining `next()` blocks the handler (asserting its own body comes back, not a JSON-RPC envelope — proving `handlePost` never ran), and that registered middleware does not leak onto the method-not-allowed routes or other routes.

## Out of scope

`policies` support on the MCP route is deferred, per the issue. Supporting it requires deciding how a policy rejection should be shaped as a JSON-RPC error.

## Docs

`docs/docs/docs/01-core/strapi/mcp-server.md` gains a `## Route middleware` section, including the caveat that `handlePost` sets `ctx.respond = false` and writes to the raw `ServerResponse` — so middleware inspecting the response after `await next()` finds `ctx.body` empty. Request-gating middleware works normally; response-rewriting middleware must wrap `ctx.res.write` / `ctx.res.end`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)